### PR TITLE
Fix pre PHP 8.2 empty string bug (fixes #28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file, in reverse
 chronological order by release.
 
+## [2.1.1](https://github.com/tuupola/base85/compare/2.1.0...2.x) - unreleased
+
+### Fixed
+- Encoding an empty string with modern PHP and PHP older than 8.2 produced different outputs ([#28](https://github.com/tuupola/base85/issues/28), [#29](https://github.com/tuupola/base85/pull/29)).
+
 ## [2.1.0](https://github.com/tuupola/base85/compare/2.0.0...2.1.0) - 2021-08-02
 
 ### Fixed

--- a/src/Base85/BaseEncoder.php
+++ b/src/Base85/BaseEncoder.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 /*
 
-Copyright (c) 2017-2021 Mika Tuupola
+Copyright (c) 2017-2025 Mika Tuupola
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Base85/BaseEncoder.php
+++ b/src/Base85/BaseEncoder.php
@@ -70,6 +70,11 @@ abstract class BaseEncoder
             $data = $matches[1];
         }
 
+        /* Handle pre PHP 8.2 str_split() behavior: https://3v4l.org/RCjgE */
+        if ($data === "") {
+            return [];
+        }
+
         if ($this->options["compress.zeroes"]) {
             $data = str_replace("z", "!!!!!", $data);
         }


### PR DESCRIPTION
Before PHP 8.2 if you pass an empty string to str_split(), it returns an array
containing a single empty string. Starting with PHP 8.2, it now returns an empty
array.

https://3v4l.org/RCjgE#veol
